### PR TITLE
Fixed Unicode error in correction of speech

### DIFF
--- a/SiriCore.py
+++ b/SiriCore.py
@@ -128,7 +128,16 @@ class Siri(LineReceiver):
     def hasNextObj(self):
         if len(self.unzipped_input) == 0:
             return False
-        cmd, data = struct.unpack('>BI', self.unzipped_input[:5])
+        #here comes a critical error! Sometimes the packet is less than :5 lets fix that
+        #Had this problem in the ruby version when a device sent a chopped ping? 
+        #solution was to replace the unziped manually with some other ping, pong value
+        try:
+            cmd, data = struct.unpack('>BI', self.unzipped_input[:5])        
+        except:
+            self.logger.info("Run into critical!!!!")
+            cmd=3
+            data=3
+            
         if cmd in (3,4): #ping pong
             return True
         if cmd == 2:

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -256,7 +256,9 @@ class SiriProtocolHandler(Siri):
                 except:
                     self.send_plist({"class":"CommandFailed", "properties": {"reason":"Database error", "errorCode":2, "callbacks":[]}, "aceId": str(uuid.uuid4()), "refId": plist['aceId'], "group":"com.apple.ace.system"})
                     self.logger.error("Database Error on setting assistant data")
-    
+            else:
+                self.send_plist({"class":"CommandFailed", "properties": {"reason":"Assistant to set data not found", "errorCode":2, "callbacks":[]}, "aceId": str(uuid.uuid4()), "refId": plist['aceId'], "group":"com.apple.ace.system"})
+                self.logger.error("Trying to set assistant data without having a valid assistant")
         elif plist['class'] == 'LoadAssistant':
             try:
                 c = self.dbConnection.cursor()
@@ -268,8 +270,7 @@ class SiriProtocolHandler(Siri):
                 else:
                     self.assistant = result[0]
                     if self.assistant.language=='' or self.assistant.language==None:
-                        print "No language"
-                        c = dbConnection.cursor()
+                        print "No language"                        
                         c.execute("delete from assistants where assistantId = ?", (reqObject['properties']['assistantId'],))
                         dbConnection.commit()
                         self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -274,7 +274,7 @@ class SiriProtocolHandler(Siri):
                         self.logger.error ("No language is set for this assistant")                        
                         c.execute("delete from assistants where assistantId = ?", (reqObject['properties']['assistantId'],))
                         dbConnection.commit()
-                        self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
+                        self.send_plist({"class":"CommandFailed", "properties": {"reason":"Database error Assistant not found or languare settings ", "errorCode":2, "callbacks":[]}, "aceId": str(uuid.uuid4()), "refId": reqObject['aceId'], "group":"com.apple.ace.system"})
                     else:                        
                         self.send_plist({"class": "AssistantLoaded", "properties": {"version": "20111216-32234-branches/telluride?cnxn=293552c2-8e11-4920-9131-5f5651ce244e", "requestSync":False, "dataAnchor":"removed"}, "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
                 c.close()

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -267,10 +267,11 @@ class SiriProtocolHandler(Siri):
                 result = c.fetchone()
                 if result == None:
                     self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
+                    self.logger.error ("Assistant not found in database!!")                        
                 else:
                     self.assistant = result[0]
                     if self.assistant.language=='' or self.assistant.language==None:
-                        print "No language"                        
+                        self.logger.error ("No language is set for this assistant")                        
                         c.execute("delete from assistants where assistantId = ?", (reqObject['properties']['assistantId'],))
                         dbConnection.commit()
                         self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -215,7 +215,8 @@ class SiriProtocolHandler(Siri):
             
         elif plist['class'] == 'CreateAssistant':
             #create a new assistant
-            helper = Assistant()           
+            helper = Assistant()     
+            helper.assistantId=str.upper(str(uuid.uuid4())) 
             c = self.dbConnection.cursor()
             noError = True
             try:

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -215,7 +215,7 @@ class SiriProtocolHandler(Siri):
             
         elif plist['class'] == 'CreateAssistant':
             #create a new assistant
-            helper = Assistant()
+            helper = Assistant()           
             c = self.dbConnection.cursor()
             noError = True
             try:
@@ -240,6 +240,16 @@ class SiriProtocolHandler(Siri):
                     self.assistant.timeZoneId = objProperties['timeZoneId']
                     self.assistant.language = objProperties['language']
                     self.assistant.region = objProperties['region']
+                    #Record the user firstName and nickName                    
+                    try:                        
+                        self.assistant.firstName=objProperties["meCards"][0]["properties"]["firstName"].encode("utf-8")
+                    except KeyError:
+                        self.assistant.firstName=u''                        
+                    try:                        
+                        self.assistant.nickName=objProperties["meCards"][0]["properties"]["nickName"].encode("utf-8")       
+                    except KeyError:
+                        self.assistant.nickName=u''
+                    #Done recording
                     c.execute("update assistants set assistant = ? where assistantId = ?", (self.assistant, self.assistant.assistantId))
                     self.dbConnection.commit()
                     c.close()

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -268,10 +268,11 @@ class SiriProtocolHandler(Siri):
                 else:
                     self.assistant = result[0]
                     if self.assistant.language=='' or self.assistant.language==None:
+                        print "No language"
                         c = dbConnection.cursor()
                         c.execute("delete from assistants where assistantId = ?", (reqObject['properties']['assistantId'],))
                         dbConnection.commit()
-                        self.send_plist({"class":"CommandFailed", "properties": {"reason":"Database error Assistant not found or languare settings ", "errorCode":2, "callbacks":[]}, "aceId": str(uuid.uuid4()), "refId": reqObject['aceId'], "group":"com.apple.ace.system"})
+                        self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
                     else:                        
                         self.send_plist({"class": "AssistantLoaded", "properties": {"version": "20111216-32234-branches/telluride?cnxn=293552c2-8e11-4920-9131-5f5651ce244e", "requestSync":False, "dataAnchor":"removed"}, "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
                 c.close()

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -166,7 +166,7 @@ class SiriProtocolHandler(Siri):
             encoder.encode(pcm)
                 
         elif plist['class'] == 'StartCorrectedSpeechRequest':
-            self.process_recognized_speech({u'hypotheses': [{'confidence': 1.0, 'utterance': str.lower(plist['properties']['utterance'])}]}, plist['aceId'], False)
+            self.process_recognized_speech({u'hypotheses': [{'confidence': 1.0, 'utterance': plist['properties']['utterance']}]}, plist['aceId'], False)
     
         elif ObjectIsCommand(plist, FinishSpeech):
             self.logger.debug("End of speech received")

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -23,8 +23,8 @@ import sqlite3
 import uuid
 
 class SiriProtocolHandler(Siri):
-    __not_recognized = {"de-DE": u"Entschuldigung, ich verstehe \"{0}\" nicht.", "en-US": u"Sorry I don't understand {0}"}
-    __websearch = {"de-DE": u"Websuche", "en-US": u"Websearch"}
+    __not_recognized =  {"de-DE": u"Entschuldigung, ich verstehe \"{0}\" nicht.", "en-US": u"Sorry I don't understand {0}", "fr-FR": u"Désolé je ne comprends pas ce que \"{0}\" veut dire."}
+    __websearch =  {"de-DE": u"Websuche", "en-US": u"Websearch", "fr-FR": u"Rechercher sur le Web"}
     
     
     def __init__(self, server, peer):

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -267,7 +267,13 @@ class SiriProtocolHandler(Siri):
                     self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
                 else:
                     self.assistant = result[0]
-                    self.send_plist({"class": "AssistantLoaded", "properties": {"version": "20111216-32234-branches/telluride?cnxn=293552c2-8e11-4920-9131-5f5651ce244e", "requestSync":False, "dataAnchor":"removed"}, "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
+                    if self.assistant.language=='' or self.assistant.language==None:
+                        c = dbConnection.cursor()
+                        c.execute("delete from assistants where assistantId = ?", (reqObject['properties']['assistantId'],))
+                        dbConnection.commit()
+                        self.send_plist({"class":"CommandFailed", "properties": {"reason":"Database error Assistant not found or languare settings ", "errorCode":2, "callbacks":[]}, "aceId": str(uuid.uuid4()), "refId": reqObject['aceId'], "group":"com.apple.ace.system"})
+                    else:                        
+                        self.send_plist({"class": "AssistantLoaded", "properties": {"version": "20111216-32234-branches/telluride?cnxn=293552c2-8e11-4920-9131-5f5651ce244e", "requestSync":False, "dataAnchor":"removed"}, "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})
                 c.close()
             except:
                 self.send_plist({"class": "AssistantNotFound", "aceId":str(uuid.uuid4()), "refId":plist['aceId'], "group":"com.apple.ace.system"})

--- a/db.py
+++ b/db.py
@@ -27,12 +27,15 @@ def getConnection():
     return None
 
 class Assistant(object):
-    def __init__(self, assistantId=str.upper(str(uuid4()))):
-        self.assistantId = assistantId
-        self.censorspeech = None
+    def __init__(self):
+        self.assistantId = None
+        self.speechId= None    
+        self.censorSpeech = None
         self.timeZoneId = None
         self.language = None
         self.region = None
+        self.nickName = u''
+        self.firstName=u''
 
 
 def adaptAssistant(assistant):

--- a/plugin.py
+++ b/plugin.py
@@ -191,3 +191,12 @@ class Plugin(threading.Thread):
             speakableText = text
         view.views += [AssistantUtteranceView(text, speakableText)]
         self.send_object(view)
+        
+    def user_name(self):
+        if self.assistant.nickName!='':
+            self.user_name=self.assistant.nickName.decode("utf-8")
+        elif self.assistant.firstName!='':
+            self.user_name=self.assistant.firstName.decode("utf-8")
+        else:
+            self.user_name=u''
+        return self.user_name

--- a/plugins/examplePlugin/__init__.py
+++ b/plugins/examplePlugin/__init__.py
@@ -18,6 +18,18 @@ class examplePlugin(Plugin):
             self.say("I shouldn't tell you {0}!".format(self.user_name()))
         self.complete_request()
 
+    @register("de-DE", "(.*Hallo.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
+    @register("en-US", "(.*Hello.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
+    @register("fr-FR", ".*(Bonjour|Coucou|Salut)( Siri)?.*")
+    def st_hello(self, speech, language):
+        if language == 'de-DE':
+            self.say(u"Hallo {0}!".format(self.user_name()))
+        elif language == 'fr-FR':
+            self.say(u"Bonjour {0}!".format(self.user_name()));
+        else:
+            self.say(u"Greetings, {0}!".format(self.user_name()))
+        self.complete_request()
+    
     @register("de-DE", ".*standort.*test.*")
     @register("en-US", ".*location.*test.*")
     def locationTest(self, speech, language):

--- a/plugins/examplePlugin/__init__.py
+++ b/plugins/examplePlugin/__init__.py
@@ -15,7 +15,7 @@ class examplePlugin(Plugin):
             answer = self.ask(u"Willst du das wirklich wissen?")
             self.say(u"Du hast \"{0}\" gesagt!".format(answer))
         else:
-            self.say("I shouldn't tell you {0}!".format(self.user_name()))
+            self.say("I shouldn't tell you!")
         self.complete_request()
 
     @register("de-DE", "(.*Hallo.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")

--- a/plugins/examplePlugin/__init__.py
+++ b/plugins/examplePlugin/__init__.py
@@ -15,7 +15,7 @@ class examplePlugin(Plugin):
             answer = self.ask(u"Willst du das wirklich wissen?")
             self.say(u"Du hast \"{0}\" gesagt!".format(answer))
         else:
-            self.say("I shouldn't tell you!")
+            self.say("I shouldn't tell you {0}!".format(self.user_name()))
         self.complete_request()
 
     @register("de-DE", ".*standort.*test.*")


### PR DESCRIPTION
This happens when a user corrents the speech and uses unicode. Python exception 

 self.process_recognized_speech({u'hypotheses': [{'confidence': 1.0, 'utterance': plist['properties']['utterance']}]}, plist['aceId'], False)
exceptions.TypeError: descriptor 'lower' requires a 'str' object but received a 'unicode'
