### PR TITLE
Allow plugins to match against generic languages

### DIFF
--- a/PluginManager.py
+++ b/PluginManager.py
@@ -4,6 +4,7 @@ from types import FunctionType
 import logging
 import os
 import re
+import languageutils
 
 
 
@@ -111,18 +112,9 @@ def searchPrioritizedPlugin(assistantId, speech, languages):
                         return (pluginObj, method, match)
     return (None, None, None)
 
-def getLanguageCodes(language):
-    languages = list()
-    while True:
-        languages.append(language)
-        if '-' not in language:
-            break
-        language = re.sub('-[^-]*$', '', language)
-    return languages
-
 def getPluginForImmediateExecution(assistantId, speech, language, otherPluginParams):
     (sendObj, sendPlist, assistant, location) = otherPluginParams
-    languages = getLanguageCodes(language)
+    languages = languageutils.getCompatibleCodes(language)
 
     (pluginObj, method, match) = searchPrioritizedPlugin(assistantId, speech, languages)
     if pluginObj == None and method == None:

--- a/PluginManager.py
+++ b/PluginManager.py
@@ -84,9 +84,10 @@ def getPlugin(speech, languages):
         for language in languages:
             if language in plugin_actions:
                 for (regex, method) in plugin_actions[language]:
-                    if regex.match(speech) != None:
-                        return (clazz, method)
-    return (None, None)
+                    match = regex.match(speech)
+                    if match != None:
+                        return (clazz, method, match)
+    return (None, None, None)
 
 def clearPriorityFor(assistantId):
     if assistantId in prioritizedPlugins:
@@ -105,9 +106,10 @@ def searchPrioritizedPlugin(assistantId, speech, languages):
         for language in languages:
             if language in plugin_actions:
                 for (regex, method) in plugin_actions[language]:
-                    if regex.match(speech) != None:
-                        return (pluginObj, method)
-    return (None, None)
+                    match = regex.match(speech)
+                    if match != None:
+                        return (pluginObj, method, match)
+    return (None, None, None)
 
 def getLanguageCodes(language):
     languages = list()
@@ -122,18 +124,18 @@ def getPluginForImmediateExecution(assistantId, speech, language, otherPluginPar
     (sendObj, sendPlist, assistant, location) = otherPluginParams
     languages = getLanguageCodes(language)
 
-    (pluginObj, method) = searchPrioritizedPlugin(assistantId, speech, languages)
+    (pluginObj, method, match) = searchPrioritizedPlugin(assistantId, speech, languages)
     if pluginObj == None and method == None:
-        (clazz, method) = getPlugin(speech, languages)
+        (clazz, method, match) = getPlugin(speech, languages)
         if clazz != None and method != None:
             logger.debug("Instantiating plugin and method: {0}.{1}".format(clazz.__name__, method.__name__))
             pluginObj = clazz()
-            pluginObj.initialize(method, speech, language, sendObj, sendPlist, assistant, location)
+            pluginObj.initialize(method, speech, language, sendObj, sendPlist, assistant, location, match)
             #prioritizePluginObject(pluginObj, assistantId)
     else:
         #reinitialize it
         logger.info("Found a matching prioritized plugin")
-        pluginObj.initialize(method, speech, language, sendObj, sendPlist, assistant, location)
+        pluginObj.initialize(method, speech, language, sendObj, sendPlist, assistant, location, match)
     
     return pluginObj
         

--- a/languageutils.py
+++ b/languageutils.py
@@ -1,0 +1,13 @@
+import re
+
+def getCompatibleCodes(language):
+    languages = list()
+    while True:
+        languages.append(language)
+        if '-' not in language:
+            break
+        language = re.sub('-[^-]*$', '', language)
+    return languages
+
+def matches(baseLanguage, specificLanguage):
+    return baseLanguage in getCompatibleCodes(specificLanguage)

--- a/languageutils.py
+++ b/languageutils.py
@@ -6,7 +6,7 @@ def getCompatibleCodes(language):
         languages.append(language)
         if '-' not in language:
             break
-        language = re.sub('-[^-]*$', '', language)
+        language = language[:language.rfind('-')]
     return languages
 
 def matches(baseLanguage, specificLanguage):

--- a/languageutils.py
+++ b/languageutils.py
@@ -11,3 +11,11 @@ def getCompatibleCodes(language):
 
 def matches(baseLanguage, specificLanguage):
     return baseLanguage in getCompatibleCodes(specificLanguage)
+
+def lookupTranslation(translations, language, default=None):
+	for lang in getCompatibleCodes(language):
+		if lang in translations:
+			return translations[lang]
+	if default in translations:
+		return translations[default]
+	return None

--- a/plugin.py
+++ b/plugin.py
@@ -124,7 +124,7 @@ class Plugin(threading.Thread):
         self.__priority = False
         self.__shouldCancel = False
     
-    def initialize(self, method, speech, language, send_object, send_plist, assistant, location):
+    def initialize(self, method, speech, language, send_object, send_plist, assistant, location, match):
         super(Plugin, self).__init__()
         self.__method = method
         self.__lang = language
@@ -133,6 +133,7 @@ class Plugin(threading.Thread):
         self.__send_object = send_object
         self.assistant = assistant
         self.location = location
+        self.__match = match
         self.__shouldCancel = False
         self.__priority = False
         
@@ -147,7 +148,7 @@ class Plugin(threading.Thread):
                 if len(arguments) == 3:
                     self.__method(self, self.__speech, self.__lang)
                 elif len(arguments) == 4:
-                    self.__method(self, self.__speech, self.__lang, self.__method.__dict__[__criteria_key__][self.__lang].match(self.__speech))
+                    self.__method(self, self.__speech, self.__lang, self.__match)
                 if self.__priority:
                     PluginManager.prioritizePluginObject(self, self.assistant.assistantId)
                 else:

--- a/plugins/examplePlugin/__init__.py
+++ b/plugins/examplePlugin/__init__.py
@@ -5,37 +5,38 @@
 from plugin import *
 from siriObjects.systemObjects import ResultCallback
 import uuid
+import languageutils
 
 class examplePlugin(Plugin):
     
-    @register("de-DE", ".*Sinn.*Leben.*")
-    @register("en-US", ".*Meaning.*Life.*")
+    @register("de", ".*Sinn.*Leben.*")
+    @register("en", ".*Meaning.*Life.*")
     def meaningOfLife(self, speech, language, matchedRegex):
-        if language == 'de-DE':
+        if languageutils.matches('de', language):
             answer = self.ask(u"Willst du das wirklich wissen?")
             self.say(u"Du hast \"{0}\" gesagt!".format(answer))
         else:
             self.say("I shouldn't tell you!")
         self.complete_request()
 
-    @register("de-DE", "(.*Hallo.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
-    @register("en-US", "(.*Hello.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
-    @register("fr-FR", ".*(Bonjour|Coucou|Salut)( Siri)?.*")
-    @register("nl-NL", ".*(Hallo|Goeiedag|Heey)( Siri)?.*")
+    @register("de", "(.*Hallo.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
+    @register("en", "(.*Hello.*)|(.*Hi.*Siri.*)|(Hi)|(Hey)")
+    @register("fr", ".*(Bonjour|Coucou|Salut)( Siri)?.*")
+    @register("nl", ".*(Hallo|Goeiedag|Heey)( Siri)?.*")
     def st_hello(self, speech, language):
-        if language == 'de-DE':
+        if languageutils.matches('de', language):
             self.say(u"Hallo {0}!".format(self.user_name()))
-        elif language == 'fr-FR':
+        elif languageutils.matches('fr', language):
             self.say(u"Bonjour {0}!".format(self.user_name()));
-        elif language == 'nl-NL':
+        elif languageutils.matches('nl', language):
             self.say(u"Hallo, {0}!".format(self.user_name()));
         else:
             self.say(u"Greetings, {0}!".format(self.user_name()))
         self.complete_request()
     
-    @register("de-DE", ".*standort.*test.*")
-    @register("en-US", ".*location.*test.*")
-    @register("nl-NL", ".*locatie.*test.*")
+    @register("de", ".*standort.*test.*")
+    @register("en", ".*location.*test.*")
+    @register("nl", ".*locatie.*test.*")
     def locationTest(self, speech, language):
         location = self.getCurrentLocation(force_reload=True)
         self.say(u"lat: {0}, long: {1}".format(location.latitude, location.longitude))


### PR DESCRIPTION
As an en-GB user it is annoying that most plugins only provide an en-US match and thus do not work. These patches allow plugins to instead specify just 'en' (or other base language) and have it match en-GB, en-US, etc.
