### PR TITLE
Added server handling of SetAlertContext and ClearContext commands

### DIFF
--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -12,8 +12,8 @@ from siriObjects.speechObjects import Phrase, Recognition, SpeechRecognized, \
 from siriObjects.systemObjects import StartRequest, SendCommands, CancelRequest, \
     CancelSucceeded, GetSessionCertificate, GetSessionCertificateResponse, \
     CreateSessionInfoRequest, CommandFailed, RollbackRequest, CreateAssistant, \
-    AssistantCreated, SetAssistantData, LoadAssistant, AssistantNotFound, \
-    AssistantLoaded, DestroyAssistant, AssistantDestroyed
+    AssistantCreated, SetAssistantData, SetAlertContext, LoadAssistant,  \
+    AssistantNotFound, AssistantLoaded, DestroyAssistant, AssistantDestroyed
 from siriObjects.uiObjects import UIAddViews, UIAssistantUtteranceView, UIButton
 import PluginManager
 import flac
@@ -352,6 +352,10 @@ class SiriProtocolHandler(Siri):
                 cmdFailed.errorCode = 2
                 self.send_object(cmdFailed)
                 self.logger.warning("Trying to set assistant data without having a valid assistant")
+                
+        elif ObjectIsCommand(plist, SetAlertContext):
+                alertContext = SetAlertContext(plist)
+                self.assistant.alerts = alertContext.context
                 
         elif ObjectIsCommand(plist, LoadAssistant):
             loadAssistant = LoadAssistant(plist)

--- a/SiriProtocolHandler.py
+++ b/SiriProtocolHandler.py
@@ -12,7 +12,7 @@ from siriObjects.speechObjects import Phrase, Recognition, SpeechRecognized, \
 from siriObjects.systemObjects import StartRequest, SendCommands, CancelRequest, \
     CancelSucceeded, GetSessionCertificate, GetSessionCertificateResponse, \
     CreateSessionInfoRequest, CommandFailed, RollbackRequest, CreateAssistant, \
-    AssistantCreated, SetAssistantData, SetAlertContext, LoadAssistant,  \
+    AssistantCreated, SetAssistantData, SetAlertContext, ClearContext, LoadAssistant,  \
     AssistantNotFound, AssistantLoaded, DestroyAssistant, AssistantDestroyed
 from siriObjects.uiObjects import UIAddViews, UIAssistantUtteranceView, UIButton
 import PluginManager
@@ -356,6 +356,9 @@ class SiriProtocolHandler(Siri):
         elif ObjectIsCommand(plist, SetAlertContext):
                 alertContext = SetAlertContext(plist)
                 self.assistant.alerts = alertContext.context
+                
+        elif ObjectIsCommand(plist, ClearContext):
+                self.assistant.alerts = None
                 
         elif ObjectIsCommand(plist, LoadAssistant):
             loadAssistant = LoadAssistant(plist)

--- a/siriObjects/systemObjects/__init__.py
+++ b/siriObjects/systemObjects/__init__.py
@@ -615,6 +615,7 @@ class SetAssistantData(ServerBoundCommand):
     groupIdentifier = "com.apple.ace.system"
     def __init__(self, plist):
         self.abSources = None # @"NSArray"
+        self.alerts = None # @"NSArray"
         self.anchor = None # @"NSString"
         self.censorSpeech = None # c
         self.debugFlags = None # @"NSNumber"


### PR DESCRIPTION
I added handling of these commands to my personal server quite a while ago, and have had no problems using them. 

I added to the sms plugin built by Eichhoernchen  the ability to check for, read and reply to new messages.

This was the best way I could come up with to store the AlertContext, as it is the Assistant that is setting the alert context, as well as clearing it, each time the connection is established between the server and the assistant. It allows the context to be visible (usable) to the plugins, but only the AlertContext for that particular assistant is available to the plugin at execution.

I will upload the sms plugin with my additions to the new forms at grwh.net
